### PR TITLE
Added function to send InitializeRequest

### DIFF
--- a/SourceKit-LSP-Communicator/SourceKit-LSP-Communicator.xcodeproj/project.pbxproj
+++ b/SourceKit-LSP-Communicator/SourceKit-LSP-Communicator.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		ACB94A3B2BBB07E400964D48 /* SourceKit_LSP_CommunicatorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACB94A3A2BBB07E400964D48 /* SourceKit_LSP_CommunicatorUITests.swift */; };
 		ACB94A3D2BBB07E400964D48 /* SourceKit_LSP_CommunicatorUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACB94A3C2BBB07E400964D48 /* SourceKit_LSP_CommunicatorUITestsLaunchTests.swift */; };
 		ACB94A4C2BBB121C00964D48 /* LSPBindings in Frameworks */ = {isa = PBXBuildFile; productRef = ACB94A4B2BBB121C00964D48 /* LSPBindings */; };
+		ACB94A4E2BBC500D00964D48 /* LSPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACB94A4D2BBC500D00964D48 /* LSPClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +47,7 @@
 		ACB94A362BBB07E400964D48 /* SourceKit-LSP-CommunicatorUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SourceKit-LSP-CommunicatorUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ACB94A3A2BBB07E400964D48 /* SourceKit_LSP_CommunicatorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceKit_LSP_CommunicatorUITests.swift; sourceTree = "<group>"; };
 		ACB94A3C2BBB07E400964D48 /* SourceKit_LSP_CommunicatorUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceKit_LSP_CommunicatorUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		ACB94A4D2BBC500D00964D48 /* LSPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClient.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -100,6 +102,7 @@
 			children = (
 				ACB94A1E2BBB07E200964D48 /* SourceKit_LSP_CommunicatorApp.swift */,
 				ACB94A202BBB07E200964D48 /* ContentView.swift */,
+				ACB94A4D2BBC500D00964D48 /* LSPClient.swift */,
 				ACB94A222BBB07E400964D48 /* Assets.xcassets */,
 				ACB94A272BBB07E400964D48 /* SourceKit_LSP_Communicator.entitlements */,
 				ACB94A242BBB07E400964D48 /* Preview Content */,
@@ -277,6 +280,7 @@
 			files = (
 				ACB94A212BBB07E200964D48 /* ContentView.swift in Sources */,
 				ACB94A1F2BBB07E200964D48 /* SourceKit_LSP_CommunicatorApp.swift in Sources */,
+				ACB94A4E2BBC500D00964D48 /* LSPClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SourceKit-LSP-Communicator/SourceKit-LSP-Communicator/ContentView.swift
+++ b/SourceKit-LSP-Communicator/SourceKit-LSP-Communicator/ContentView.swift
@@ -1,15 +1,24 @@
 import SwiftUI
 
 struct ContentView: View {
+    private let client = LSPClient()
+    @State private var rootPathString = ""
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-        }
+        Form {
+            Section(header: Text("Initialization")) {
+                TextField(
+                    "Project root path",
+                    text: $rootPathString
+                )
+                Button("Send Initialize Request") {
+                    client.sendInitializeRequest(projectRootPathString: rootPathString)
+                }
+            }
+        } // VStack
         .padding()
-    }
+        .frame(width: 800)
+    } // body
 }
 
 #Preview {

--- a/SourceKit-LSP-Communicator/SourceKit-LSP-Communicator/LSPClient.swift
+++ b/SourceKit-LSP-Communicator/SourceKit-LSP-Communicator/LSPClient.swift
@@ -1,0 +1,67 @@
+import Foundation
+import LanguageServerProtocol
+import LanguageServerProtocolJSONRPC
+
+final class LSPClient {
+    private let clientToServer = Pipe()
+    private let serverToClient = Pipe()
+    private let serverProcess = Process()
+    private lazy var connection = JSONRPCConnection(
+        protocol: .lspProtocol,
+        inFD: .init(fileDescriptor: serverToClient.fileHandleForReading.fileDescriptor),
+        outFD: .init(fileDescriptor: clientToServer.fileHandleForWriting.fileDescriptor)
+    )
+    private let queue = DispatchQueue(label: "LSP-Request")
+    private let serverPath = "/Applications/Xcode-15.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp"
+
+    func sendInitializeRequest(projectRootPathString: String) {
+        connection.start(receiveHandler: Client())
+
+        serverProcess.launchPath = serverPath
+        serverProcess.standardInput = clientToServer
+        serverProcess.standardOutput = serverToClient
+        serverProcess.terminationHandler = { [weak self] _ in
+            self?.connection.close()
+        }
+        serverProcess.launch()
+
+        let rootURL = URL(fileURLWithPath: projectRootPathString)
+        let request = InitializeRequest(
+            rootURI: DocumentURI(string: rootURL.deletingLastPathComponent().absoluteString),
+            capabilities: ClientCapabilities(),
+            workspaceFolders: nil
+        )
+
+        dump(request, name: "InitializeRequest")
+        print("")
+
+        _ = connection.send(
+            request,
+            queue: queue,
+            reply: { result in
+                switch result {
+                case .success(let response):
+                    print("\nINITIALIZATION SUCCEEDED\n")
+                    dump(response)
+                case .failure(let error):
+                    print("\nINITIALIZATION FAILED...\n")
+                    print(error)
+                }
+            }
+        )
+    }
+}
+
+private final class Client: MessageHandler {
+    func handle<Notification>(
+        _: Notification,
+        from: ObjectIdentifier
+    ) where Notification : NotificationType {}
+
+    func handle<Request>(
+        _: Request,
+        id: RequestID,
+        from: ObjectIdentifier,
+        reply: @escaping (LSPResult<Request.Response>) -> Void
+    ) where Request : RequestType {}
+}


### PR DESCRIPTION
However, since the message `could not find manifest, or not a SwiftPM package:` is received, it is necessary to verify that the InitializeRequest is correctly sent when implementing other requests.